### PR TITLE
Add western cuisine category mapping

### DIFF
--- a/app/api/places/route.ts
+++ b/app/api/places/route.ts
@@ -107,6 +107,7 @@ const getMockRestaurants = (type: string, minRating = 0, radius = 1000, isKorea 
       korean_restaurant: "한식",
       japanese_restaurant: "일식",
       chinese_restaurant: "중식",
+      western_restaurant: "양식",
       cafe: "카페",
     }
     const targetCategory = categoryMap[type]
@@ -171,6 +172,7 @@ async function searchNaverPlaces(
     korean_restaurant: "한식",
     japanese_restaurant: "일식",
     chinese_restaurant: "중식",
+    western_restaurant: "양식",
     cafe: "카페",
     restaurant: "음식점", // 일반 음식점
     all: "맛집", // 전체 검색

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -74,7 +74,7 @@ export default function Home() {
   const categories = [
     { id: "all", name: "전체", types: [] },
     { id: "korean", name: "한식", types: ["korean_restaurant"] },
-    { id: "western", name: "양식", types: ["restaurant"] },
+    { id: "western", name: "양식", types: ["western_restaurant"] }, // Google Places의 'western_restaurant' 타입을 사용하여 양식만 검색
     { id: "japanese", name: "일식", types: ["japanese_restaurant"] },
     { id: "chinese", name: "중식", types: ["chinese_restaurant"] },
     { id: "cafe", name: "카페", types: ["cafe"] },


### PR DESCRIPTION
## Summary
- use `western_restaurant` type for Western cuisine category on homepage
- map `western_restaurant` to "양식" in API keyword and mock data

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689a98c11b7083278f0d62e44396e2ea